### PR TITLE
Remove the original file generated

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -35,10 +35,12 @@ module.exports = class Gzip
 
   _compress: (path, file) ->
     gzip   = zlib.createGzip level: zlib.Z_BEST_COMPRESSION
-    input  = fs.createReadStream "#{path}/#{file}"
+    input_path = "#{path}/#{file}"
+    input  = fs.createReadStream input_path
     output = fs.createWriteStream "#{path}/#{file}.gz"
     # Delete the original file generated
-    fs.unlinkSync("" + path + "/" + file)
+    if fs.existsSync(input_path)
+      fs.unlinkSync("" + path + "/" + file)
     input.pipe(gzip).pipe output
 
   _joinToPublic: (path) =>


### PR DESCRIPTION
Once compressed, the source file can be deleted as it mostly likely is not needed.
