### PR TITLE
From CoffeeScript 1.7+, they require to write --compilers coffee:coffee-script/register

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "./lib/index",
   "scripts": {
     "prepublish": "rm -rf lib && coffee --bare --output lib/ src/",
-    "test": "node_modules/.bin/mocha --compilers coffee:coffee-script --require test/common.js"
+    "test": "node_modules/.bin/mocha"
   },
   "devDependencies": {
     "mocha": "1.13.0",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--compilers coffee:coffee-script/register
+--require test/common.js


### PR DESCRIPTION
From CoffeeScript 1.7+, they require to write --compilers coffee:coffee-script/register

refs: http://visionmedia.github.io/mocha/#compilers-option
