### PR TITLE
Fixing default javascripts/stylesheets-path values

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -13,11 +13,11 @@ module.exports = class Gzip
         ext:  /\.html$/
       }
       {
-        path: @_joinToPublic @options.paths?.javascript or 'javascripts'
+        path: @_joinToPublic @options.paths?.javascript or ''
         ext:  /\.js$/
       }
       {
-        path: @_joinToPublic @options.paths?.stylesheet or 'stylesheets'
+        path: @_joinToPublic @options.paths?.stylesheet or ''
         ext:  /\.css$/
       }
     ]

--- a/test/plugin-test.coffee
+++ b/test/plugin-test.coffee
@@ -14,8 +14,8 @@ describe "Plugin", ->
     context 'when default', ->
       it "should have targets", ->
         expect(@plugin.targets[0].path).to.be.eql 'public'
-        expect(@plugin.targets[1].path).to.be.eql 'public/javascripts'
-        expect(@plugin.targets[2].path).to.be.eql 'public/stylesheets'
+        expect(@plugin.targets[1].path).to.be.eql 'public'
+        expect(@plugin.targets[2].path).to.be.eql 'public'
 
     context 'when configured', ->
       beforeEach ->


### PR DESCRIPTION
A fresh brunch-project places js/css-files in public/. The default values in gzip-brunch don't match this.
